### PR TITLE
Fixed: Correct dotnev version in package.json in Backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
-    "dotenv": "^16.b4.7",
+    "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",


### PR DESCRIPTION
Fixed dotenv version from 16.b4.7 to 16.4.7 present in Backend/package.json